### PR TITLE
Now collects the mean and max run_delay values for all VMs.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/hiboma/mackerel-plugin-scheduler-latency-kvm
 
 go 1.15
 
-require github.com/prometheus/procfs v0.6.0
+require (
+	github.com/montanaflynn/stats v0.6.6
+	github.com/prometheus/procfs v0.6.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/montanaflynn/stats v0.6.6 h1:Duep6KMIDpY4Yo11iFsvyqJDyfzLF9+sndUKT+v64GQ=
+github.com/montanaflynn/stats v0.6.6/go.mod h1:etXPPgVO6n31NxCd9KQUMvCM+ve0ruNzt6R8Bnaayow=
 github.com/prometheus/procfs v0.6.0 h1:mxy4L2jP6qMonqmq+aTtOx1ifVWUgG/TAmntgbh3xv4=
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/kvm_steal.go
+++ b/kvm_steal.go
@@ -29,7 +29,6 @@ func collectVMProcesses() (procfs.Procs, error) {
 		cmdline, err := p.CmdLine()
 		if err != nil {
 			return nil, err
-			break
 		}
 
 		/* skip kernel therad */

--- a/kvm_steal.go
+++ b/kvm_steal.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/montanaflynn/stats"
 	"github.com/prometheus/procfs"
 )
 
@@ -168,6 +169,7 @@ func main() {
 		time.Sleep(interval)
 		currentStats := collectRundelay(vms)
 
+		var deltaStats []float64
 		now := time.Now()
 		for name, _ := range prevStats {
 
@@ -182,6 +184,17 @@ func main() {
 
 			deltaRunDelay := currentStats[name] - prevStats[name]
 			fmt.Printf("vm.%s.run_delay\t%f\t%d\n", name, deltaRunDelay/1000/1000/1000*100, now.Unix())
+
+			deltaStats = append(deltaStats, deltaRunDelay)
 		}
+
+		if meanRunDelay, err := stats.Mean(deltaStats); err == nil {
+			fmt.Printf("vm.all.mean_run_delay\t%f\t%d\n", meanRunDelay/1000/1000/1000*100, now.Unix())
+		}
+
+		if maxRunDelay, err := stats.Max((deltaStats)); err == nil {
+			fmt.Printf("vm.all.max_run_delay\t%f\t%d\n", maxRunDelay/1000/1000/1000*100, now.Unix())
+		}
+
 	}
 }


### PR DESCRIPTION
すべてのVMのrun_delayの平均値と最大値を取るようにしました。
ユースケースとしては、VMが大量にありデータの点数が増えてくると、集計する側で時間がかかりすぎてしまうためです。
なお、パーセンタイルを取ろうとしましたがそれが取れるほどデータの点数がないのでやめました。