### PR TITLE
Update Go dependencies to latest compatible versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,19 +9,19 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       -
         name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.16
+          go-version: '1.24'
       -
         name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v6
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,44 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+Mackerel custom plugin that collects CPU scheduler latency (run_delay) metrics for KVM virtual machines. It reads `/proc/<pid>/task/<tid>/schedstat` for each qemu-system-x86_64 process to measure scheduling delays, then outputs Mackerel-formatted metrics (per-VM run_delay, mean, and max across all VMs).
+
+Requires `CONFIG_SCHEDSTATS` enabled in the Linux kernel. Runs only on Linux.
+
+## Build and Test
+
+```bash
+make build    # go build .
+make test     # go test .
+```
+
+## Release
+
+Releases are managed by GoReleaser, triggered by pushing a git tag. Semantic versioning tags are created via `git-semv` (installed from Homebrew tap `linyows/git-semv`).
+
+```bash
+make release_patch   # bump patch version and push tag
+make release_minor   # bump minor version and push tag
+make release_major   # bump major version and push tag
+```
+
+The GitHub Actions workflow (`.github/workflows/release.yml`) runs GoReleaser on tag push to produce linux/amd64 binaries in deb/rpm formats.
+
+## Architecture
+
+Single-file Go program (`kvm_steal.go`) with no Mackerel plugin helper library — it directly prints tab-separated metrics to stdout in `key\tvalue\ttimestamp` format.
+
+Key flow in `main()`:
+1. Check `/proc/self/schedstat` exists (kernel config guard)
+2. `collectVMProcesses()` — find all `qemu-system-x86_64` processes via procfs
+3. `collectRundelay()` — for each VM, sum `RunDelay` from schedstat across all threads (TIDs)
+4. Sleep 1 second, collect again, compute delta to get per-second run_delay
+5. `guessVMName()` — extract VM name from qemu `-name` cmdline argument (dots replaced with hyphens)
+6. Output per-VM and aggregate (mean/max) metrics
+
+Dependencies:
+- `github.com/prometheus/procfs` — process enumeration from /proc
+- `github.com/montanaflynn/stats` — mean/max statistical functions

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,12 @@
 module github.com/hiboma/mackerel-plugin-scheduler-latency-kvm
 
-go 1.15
+go 1.24.0
+
+toolchain go1.24.11
 
 require (
-	github.com/montanaflynn/stats v0.6.6
-	github.com/prometheus/procfs v0.6.0
+	github.com/montanaflynn/stats v0.9.0
+	github.com/prometheus/procfs v0.19.2
 )
+
+require golang.org/x/sys v0.37.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,8 @@
-github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/montanaflynn/stats v0.6.6 h1:Duep6KMIDpY4Yo11iFsvyqJDyfzLF9+sndUKT+v64GQ=
-github.com/montanaflynn/stats v0.6.6/go.mod h1:etXPPgVO6n31NxCd9KQUMvCM+ve0ruNzt6R8Bnaayow=
-github.com/prometheus/procfs v0.6.0 h1:mxy4L2jP6qMonqmq+aTtOx1ifVWUgG/TAmntgbh3xv4=
-github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
-golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c h1:VwygUrnw9jn88c4u8GD3rZQbqrP/tgas88tPUbBxQrk=
-golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/montanaflynn/stats v0.9.0 h1:tsBJ0RXwph9BmAuFoCmqGv6e8xa0MENQ8m0ptKq29mQ=
+github.com/montanaflynn/stats v0.9.0/go.mod h1:etXPPgVO6n31NxCd9KQUMvCM+ve0ruNzt6R8Bnaayow=
+github.com/prometheus/procfs v0.19.2 h1:zUMhqEW66Ex7OXIiDkll3tl9a1ZdilUOd/F6ZXw4Vws=
+github.com/prometheus/procfs v0.19.2/go.mod h1:M0aotyiemPhBCM0z5w87kL22CxfcH05ZpYlu+b4J7mw=
+golang.org/x/sys v0.37.0 h1:fdNQudmxPjkdUTPnLn5mdQv7Zwvbvpaxqs831goi9kQ=
+golang.org/x/sys v0.37.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=

--- a/kvm_steal.go
+++ b/kvm_steal.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
@@ -120,7 +119,7 @@ func collectRundelay(vms procfs.Procs) map[string]float64 {
 
 		for _, tid := range tids {
 			path := fmt.Sprintf("/proc/%d/task/%d/schedstat", tid, tid)
-			bytes, err := ioutil.ReadFile(path)
+			bytes, err := os.ReadFile(path)
 			if err != nil {
 				return nil
 			}


### PR DESCRIPTION
## Summary

Update all Go dependencies to their latest versions compatible with Go 1.24, and fix related issues found during review.

## Why

Dependencies were significantly outdated (prometheus/procfs v0.6.0, montanaflynn/stats v0.6.6, Go 1.15). Updating brings bug fixes, performance improvements, and addresses the moderate vulnerability flagged by GitHub Dependabot.

## Changes

- **Go dependencies**: prometheus/procfs v0.6.0 -> v0.19.2, montanaflynn/stats v0.6.6 -> v0.9.0
- **Go version**: go directive 1.15 -> 1.24.0
- **Deprecated API**: Replace `ioutil.ReadFile` with `os.ReadFile` (deprecated since Go 1.16)
- **CI workflow**: Update actions/checkout@v4, actions/setup-go@v5, goreleaser-action@v6, Go 1.24
- **CLAUDE.md**: Add Claude Code guidance file

Note: prometheus/procfs v0.20.0+ requires Go 1.25, so v0.19.2 is the latest version compatible with Go 1.24.

## Test plan

- [x] `go build` succeeds
- [x] `go test` passes
- [x] `go vet` clean

🤖 Generated with [Claude Code](https://claude.ai/code)